### PR TITLE
Do not require a resolver name in table-resolver

### DIFF
--- a/docs/built-in-resolvers.mdx
+++ b/docs/built-in-resolvers.mdx
@@ -113,11 +113,11 @@ You can use static tables to provide extra data for some entities, given some id
 
 ```clojure
 (def registry
-  [(pbir/static-table-resolver `song-names :song/id
+  [(pbir/static-table-resolver :song/id
      {1 {:song/name "Marchinha Psicotica de Dr. Soup"}
       2 {:song/name "There's Enough"}})
 
-   ; note you need to provide the name for the resolver, prefer fully qualified symbols
+   ; you can provide a name for the resolver, prefer fully qualified symbols
    (pbir/static-table-resolver `song-analysis :song/id
      {1 {:song/duration 280 :song/tempo 98}
       2 {:song/duration 150 :song/tempo 130}})])


### PR DESCRIPTION
To reflect the change in https://github.com/wilkerlucio/pathom3/pull/5 if it gets merged.