### PR TITLE
syntax and grammar fixes

### DIFF
--- a/docs/cache.mdx
+++ b/docs/cache.mdx
@@ -82,7 +82,7 @@ of those as a cache-store.
 
 ## Persistent caching
 
-There are cases in which a persistent cache can same some processing time in the application.
+There are cases in which a persistent cache can save some processing time in the application.
 
 For example, a Pathom server handling API requests for serving some UI. This kind of
 service tends to receive the same queries over and over. Instead of re-planning on every
@@ -146,7 +146,7 @@ To demonstrate it, we will make a persistent cache using a `LRUCache` from core.
   (-> (cc/lru-cache-factory base :threshold threshold)
       (->CoreCacheStore)))
 
-; create a cache holds only the latest 100 read plans
+; create a cache that holds only the latest 100 read plans
 (defonce plan-cache* (lru-cache {} 100))
 
 (def env

--- a/docs/environment.mdx
+++ b/docs/environment.mdx
@@ -6,7 +6,6 @@ title: Environment
 The environment is a map containing contextual information, both from Pathom itself
 and from any user/library extensions.
 
-In this page you will learn
 Given the environment is a generic and open map, it makes more sense to talk about
 what features of Pathom you can see and interact with.
 

--- a/docs/eql.mdx
+++ b/docs/eql.mdx
@@ -86,7 +86,7 @@ You can provide initial data to the EQL process using the following syntax:
 ### Providing data via EQL idents
 
 Pathom uses the EQL `ident` as a form to specify a single attribute to start requesting
-data from. Here is an example using the revolvers we created before:
+data from. Here is an example using the resolvers we created before:
 
 ```clojure
 (p.eql/process indexes [{[::pi 2.3] [::tau]}])
@@ -131,7 +131,7 @@ the params data to it, to illustrate let's make a nested example of it:
 
 ### Union queries
 
-Union queries provide a way to archive polymorphism in with EQL, for a review on the
+Union queries provide a way to achieve polymorphism in EQL, for a review on the
 union syntax refer to the [EQL Union specification page](https://edn-query-language.org/eql/1.0.0/specification.html#_unions).
 
 Consider you want to request information for some user feed. In our feed example, there
@@ -424,7 +424,7 @@ It's recommended that you always use this at API boundaries.
 
 ### Extending environment
 
-The boundary API design is to make it flexible, and altough is more efficient
+The boundary API design is to make it flexible, and although is more efficient
 to initialize as much as possible before in the env, it still allows extension of
 it.
 
@@ -453,8 +453,8 @@ In this case we can set the user id on env when we call the boundary interface:
 ; => {:user/login "bunny"}
 ```
 
-In this example we sent env as a map, the boundary interface get this map and merge
-into the previous env and run.
+In this example we sent env as a map, the boundary interface gets this map and merges
+into the previous env and runs.
 
 The env extension can also be a function, this allows more complex operations like
 registering new resolvers, for example:

--- a/docs/error-handling.mdx
+++ b/docs/error-handling.mdx
@@ -13,8 +13,8 @@ Here are the reasons that may cause Pathom to throw:
 
 - Attribute doesn't exist in the indexes
 - Attribute exists in the indexes, but the available data isn't enough to reach it
-- Attribute wasn't in the final output after all the process
-- A resolver throw an exception*
+- Attribute wasn't in the final output after all the processes
+- A resolver threw an exception*
 
 :::note
 * An exception to this rule is if a resolver is contained in a OR node, if there are
@@ -54,7 +54,7 @@ Let's see one example of each of those cases:
   [:d])
 ; => EXCEPTION: Pathom can't find a path for the following elements in the query: [:c] at path [:a]
 
-; Attribute wasn't in the final output after all the process
+; Attribute wasn't in the final output after all the processes
 (p.eql/process
   (pci/register
     (pco/resolver 'data
@@ -64,7 +64,7 @@ Let's see one example of each of those cases:
   [:c])
 ; => EXCEPTION: Required attributes missing: [:c] at path []
 
-; A resolver throw an exception
+; A resolver threw an exception
 (p.eql/process
   (pci/register
     (pco/resolver 'error
@@ -110,7 +110,7 @@ This will ignore problems to fetch that attribute, except in case of an exceptio
 
 ## Lenient Mode
 
-When you Pathom scenario involves large queries (for a complex UI made with [Fulcro](https://fulcro.fulcrologic.com/)
+When your Pathom scenario involves large queries (for a complex UI made with [Fulcro](https://fulcro.fulcrologic.com/)
 for example) you probably don't want that a single attribute break the whole query.
 
 This requires a more tolerant mode, which is the lenient mode in Pathom 3.


### PR DESCRIPTION
Fixing a few typos and grammar mistakes spotted in documentation.