### PR TITLE
update code sample for plugins to use ` instead of '

### DIFF
--- a/docs/built-in-plugins.mdx
+++ b/docs/built-in-plugins.mdx
@@ -51,7 +51,7 @@ Example:
         [(pbir/single-attr-resolver :a :b inc)
          foo])
       (p.plugin/register pbip/mutation-resolve-params))
-  ['(foo {:a 1})])
+  [`(foo {:a 1})])
 ; => {foo {:res 2}}
 ```
 


### PR DESCRIPTION
Was getting this error when copying the example:
```clojure
(p.eql/process
  (-> (pci/register [(pbir/single-attr-resolver :a :b inc) foo])
    (p.plugin/register pbip/mutation-resolve-params))
  ['(foo {:a 1})])
Execution error (ExceptionInfo) at com.wsscode.pathom3.connect.runner/invoke-mutation!$fn (runner.cljc:784).
Mutation foo not found
```