### PR TITLE
Correct mistake in code example

### DIFF
--- a/docs/dynamic-resolvers.mdx
+++ b/docs/dynamic-resolvers.mdx
@@ -193,7 +193,8 @@ queries to our previous server.
 
 (def client-env
   (-> (pci/register
-        [(pcf/foreign-register request)
+        [remote-users
+         remote-company
          (pbir/static-attribute-map-resolver
            :user/id :user/ip ips)])
       (pcp/with-plan-cache (atom {}))))


### PR DESCRIPTION
The code example intends to demonstrate remote integration using static resolver. 

However, it is incorrectly written to use the foreign register which is correctly demonstrated in a later step.